### PR TITLE
Fix OG metadata generation

### DIFF
--- a/app/(default)/layout.tsx
+++ b/app/(default)/layout.tsx
@@ -82,7 +82,9 @@ const defaultMetadata = {
   title: "Bold Video x Next.js Starter Kit",
   description:
     "Bold Video Starter Kit: Supercharge videos, rapid encoding/transcription.",
-  ogImage: "https://starter-demo.bold.video/og-static.png",
+  ogImage: `https://og.boldvideo.io/api/og-image?text=${encodeURIComponent(
+    "Bold Video x Next.js Starter Kit",
+  )}`,
   siteUrl: "https://starter-demo.bold.video",
 };
 
@@ -122,7 +124,10 @@ export async function generateMetadata(): Promise<Metadata> {
     : defaultMetadata.title;
   const description = meta?.description || defaultMetadata.description;
   const ogImageUrl =
-    meta?.social_graph_image_url || meta?.image || defaultMetadata.ogImage;
+    meta?.social_graph_image_url ||
+    `https://og.boldvideo.io/api/og-image?text=${encodeURIComponent(title)}${
+      meta?.image ? `&img=${encodeURIComponent(meta.image)}` : ""
+    }`;
 
   return {
     title: title,

--- a/app/(default)/pl/[id]/page.tsx
+++ b/app/(default)/pl/[id]/page.tsx
@@ -27,11 +27,12 @@ export async function generateMetadata({
     description: playlist.description,
     openGraph: {
       title: playlist.title,
+      description: playlist.description,
       images: [
         {
-          url: `https://demo.bold.video/og?t=${encodeURIComponent(
-            `Playlist: ${playlist.title}`
-          )}&img=${encodeURIComponent(first.thumbnail)}`,
+          url: `https://og.boldvideo.io/api/og-image?text=${encodeURIComponent(
+            playlist.title,
+          )}${first ? `&img=${encodeURIComponent(first.thumbnail)}` : ""}`,
           width: 1200,
           height: 630,
         },

--- a/app/(default)/v/[id]/page.tsx
+++ b/app/(default)/v/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { bold } from "@/client";
 import { VideoDetail } from "@/components/video-detail";
 import type { Video, Settings } from "@boldvideo/bold-js";
+import { formatDuration } from "util/format-duration";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 60;
@@ -19,11 +20,14 @@ export async function generateMetadata({
     description: data.description,
     openGraph: {
       title: data.title,
+      description: data.description,
       images: [
         {
-          url: `https://demo.bold.video/og?t=${encodeURIComponent(
-            data.title
-          )}&img=${encodeURIComponent(data.thumbnail)}`,
+          url: `https://og.boldvideo.io/api/og-image?text=${encodeURIComponent(
+            data.title,
+          )}&img=${encodeURIComponent(data.thumbnail)}&l=${encodeURIComponent(
+            formatDuration(data.duration),
+          )}`,
           width: 1200,
           height: 630,
         },

--- a/app/(nolayout)/e/[id]/page.tsx
+++ b/app/(nolayout)/e/[id]/page.tsx
@@ -2,6 +2,7 @@ import { bold } from "@/client";
 // import { Player } from "components/embed-player";
 import { Player } from "@/components/players";
 import type { Video } from "@boldvideo/bold-js";
+import { formatDuration } from "util/format-duration";
 
 /**
  * Extended Video type with additional properties used in our application
@@ -23,11 +24,14 @@ export async function generateMetadata(props: {
     description: video.description,
     openGraph: {
       title: video.title,
+      description: video.description,
       images: [
         {
-          url: `https://demo.bold.video/og?t=${encodeURIComponent(
-            video.title
-          )}&img=${encodeURIComponent(video.thumbnail)}`,
+          url: `https://og.boldvideo.io/api/og-image?text=${encodeURIComponent(
+            video.title,
+          )}&img=${encodeURIComponent(video.thumbnail)}&l=${encodeURIComponent(
+            formatDuration(video.duration),
+          )}`,
           width: 1200,
           height: 630,
         },


### PR DESCRIPTION
## Summary
- use new Open Graph service for site metadata
- add OG descriptions for playlists and videos
- show OG duration badge for videos
- refresh embed page OG settings

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685784ec1c2083329b5e884558496f3d