### PR TITLE
feat: image upload UI in AI chat (BOLD-1496)

### DIFF
--- a/app/api/ai-ask/route.ts
+++ b/app/api/ai-ask/route.ts
@@ -84,6 +84,14 @@ function formatSSE(event: AIEvent, state: StreamState): string | null {
         message: event.message,
       });
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    case "image_analysis" as any:
+      return JSON.stringify({
+        type: "image_analysis",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        message: (event as any).message,
+      });
+
     default:
       return null;
   }

--- a/app/api/ai-ask/route.ts
+++ b/app/api/ai-ask/route.ts
@@ -137,17 +137,42 @@ export async function POST(request: Request) {
     );
   }
 
-  let body: AskRequestBody;
-  try {
-    body = await request.json();
-  } catch {
-    return new Response(
-      JSON.stringify({ type: "error", code: "INVALID_JSON", message: "Invalid JSON body" }),
-      { status: 400, headers: { "Content-Type": "application/json" } }
-    );
-  }
+  const contentType = request.headers.get("content-type") ?? "";
+  let prompt: string | undefined;
+  let conversationId: string | undefined;
+  let collectionId: string | undefined;
+  let images: File[] = [];
 
-  const { prompt, conversationId, collectionId } = body;
+  if (contentType.startsWith("multipart/form-data")) {
+    try {
+      const form = await request.formData();
+      const promptValue = form.get("prompt");
+      prompt = typeof promptValue === "string" ? promptValue : undefined;
+      const cid = form.get("conversationId");
+      conversationId = typeof cid === "string" ? cid : undefined;
+      const colId = form.get("collectionId");
+      collectionId = typeof colId === "string" ? colId : undefined;
+      images = form.getAll("image").filter((v): v is File => v instanceof File);
+    } catch {
+      return new Response(
+        JSON.stringify({ type: "error", code: "INVALID_MULTIPART", message: "Invalid multipart body" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+  } else {
+    let body: AskRequestBody;
+    try {
+      body = await request.json();
+    } catch {
+      return new Response(
+        JSON.stringify({ type: "error", code: "INVALID_JSON", message: "Invalid JSON body" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    prompt = body.prompt;
+    conversationId = body.conversationId;
+    collectionId = body.collectionId;
+  }
 
   if (!prompt || typeof prompt !== "string") {
     return new Response(
@@ -162,7 +187,9 @@ export async function POST(request: Request) {
       stream: true,
       conversationId,
       collectionId,
-    });
+      // BOLD-1449: pass images per the published SDK shape (cast until SDK types catch up)
+      ...(images.length > 0 ? { images } : {}),
+    } as Parameters<typeof context.client.ai.ask>[0]);
 
     const responseStream = asyncIterableToStream(
       stream as AsyncIterable<AIEvent>,

--- a/app/api/ai-ask/route.ts
+++ b/app/api/ai-ask/route.ts
@@ -48,6 +48,16 @@ function formatSSE(event: AIEvent, state: StreamState): string | null {
     case "message_complete": {
       // Use sources from event (SDK provides as citations), fall back to accumulated state
       const completeSources = event.citations || state.sources;
+      // BOLD-1463: optional user-message attachments (server-resolved URLs)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const userAttachments = (event as any).userAttachments as Array<{
+        id: string;
+        url?: string;
+        mimeType?: string;
+        width?: number;
+        height?: number;
+        name?: string;
+      }> | undefined;
       return JSON.stringify({
         type: "message_complete",
         responseType: event.responseType,
@@ -66,6 +76,14 @@ function formatSSE(event: AIEvent, state: StreamState): string | null {
         conversationId: event.conversationId || state.conversationId,
         usage: event.usage,
         context: event.context,
+        user_attachments: userAttachments?.map((a) => ({
+          id: a.id,
+          url: a.url,
+          mime_type: a.mimeType,
+          width: a.width,
+          height: a.height,
+          name: a.name,
+        })),
       });
     }
 

--- a/app/api/ai-search/route.ts
+++ b/app/api/ai-search/route.ts
@@ -87,6 +87,14 @@ function formatSSE(event: AIEvent, state: StreamState): string | null {
         message: event.message,
       });
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    case "image_analysis" as any:
+      return JSON.stringify({
+        type: "image_analysis",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        message: (event as any).message,
+      });
+
     default:
       return null;
   }

--- a/app/api/coach/route.ts
+++ b/app/api/coach/route.ts
@@ -46,6 +46,16 @@ function formatSSE(
     case "message_complete": {
       // Use sources from event (SDK provides as citations), fall back to accumulated state
       const completeSources = event.citations || state.sources;
+      // BOLD-1463: optional user-message attachments (server-resolved URLs)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const userAttachments = (event as any).userAttachments as Array<{
+        id: string;
+        url?: string;
+        mimeType?: string;
+        width?: number;
+        height?: number;
+        name?: string;
+      }> | undefined;
       return JSON.stringify({
         type: "message_complete",
         responseType: event.responseType,
@@ -64,6 +74,14 @@ function formatSSE(
         conversationId: event.conversationId || state.conversationId,
         usage: event.usage,
         context: event.context,
+        user_attachments: userAttachments?.map((a) => ({
+          id: a.id,
+          url: a.url,
+          mime_type: a.mimeType,
+          width: a.width,
+          height: a.height,
+          name: a.name,
+        })),
       });
     }
 

--- a/app/api/coach/route.ts
+++ b/app/api/coach/route.ts
@@ -82,6 +82,14 @@ function formatSSE(
         message: event.message,
       });
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    case "image_analysis" as any:
+      return JSON.stringify({
+        type: "image_analysis",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        message: (event as any).message,
+      });
+
     default:
       return null;
   }

--- a/app/api/coach/route.ts
+++ b/app/api/coach/route.ts
@@ -140,17 +140,38 @@ export async function POST(request: Request) {
     );
   }
 
-  let body: CoachRequestBody;
-  try {
-    body = await request.json();
-  } catch {
-    return new Response(
-      JSON.stringify({ type: "error", content: "Invalid JSON body" }),
-      { status: 400, headers: { "Content-Type": "application/json" } }
-    );
-  }
+  const contentType = request.headers.get("content-type") ?? "";
+  let message: string | undefined;
+  let conversationId: string | undefined;
+  let images: File[] = [];
 
-  const { message, conversationId } = body;
+  if (contentType.startsWith("multipart/form-data")) {
+    try {
+      const form = await request.formData();
+      const messageValue = form.get("message");
+      message = typeof messageValue === "string" ? messageValue : undefined;
+      const cid = form.get("conversationId");
+      conversationId = typeof cid === "string" ? cid : undefined;
+      images = form.getAll("image").filter((v): v is File => v instanceof File);
+    } catch {
+      return new Response(
+        JSON.stringify({ type: "error", content: "Invalid multipart body" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+  } else {
+    let body: CoachRequestBody;
+    try {
+      body = await request.json();
+    } catch {
+      return new Response(
+        JSON.stringify({ type: "error", content: "Invalid JSON body" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    message = body.message;
+    conversationId = body.conversationId;
+  }
 
   if (!message || typeof message !== "string") {
     return new Response(
@@ -163,7 +184,9 @@ export async function POST(request: Request) {
     const stream = await context.client.ai.coach({
       prompt: message,
       conversationId,
-    });
+      // BOLD-1449: pass images per the published SDK shape (cast until SDK types catch up)
+      ...(images.length > 0 ? { images } : {}),
+    } as Parameters<typeof context.client.ai.coach>[0]);
 
     // Convert AsyncIterable to ReadableStream with pull-based streaming
     const responseStream = asyncIterableToStream(stream as AsyncIterable<AIEvent>, conversationId);

--- a/components/ask/ask-empty-state.tsx
+++ b/components/ask/ask-empty-state.tsx
@@ -15,6 +15,12 @@ interface AskEmptyStateProps {
   suggestions: string[];
   placeholder: string;
   disclaimer?: string;
+  // Multimodal (Phase 2)
+  multimodalEnabled?: boolean;
+  images?: File[];
+  onImagesChange?: (images: File[]) => void;
+  maxImages?: number;
+  acceptedMediaTypes?: string[];
 }
 
 export function AskEmptyState({
@@ -29,6 +35,11 @@ export function AskEmptyState({
   suggestions,
   placeholder,
   disclaimer,
+  multimodalEnabled,
+  images,
+  onImagesChange,
+  maxImages,
+  acceptedMediaTypes,
 }: AskEmptyStateProps) {
   return (
     <div className="flex h-[calc(100vh-120px)] w-full items-center justify-center px-4 md:px-6">
@@ -63,6 +74,11 @@ export function AskEmptyState({
           suggestions={suggestions}
           showSuggestions={true}
           disclaimer={disclaimer}
+          multimodalEnabled={multimodalEnabled}
+          images={images}
+          onImagesChange={onImagesChange}
+          maxImages={maxImages}
+          acceptedMediaTypes={acceptedMediaTypes}
         />
       </div>
     </div>

--- a/components/ask/ask-page-content.tsx
+++ b/components/ask/ask-page-content.tsx
@@ -37,9 +37,11 @@ export function AskPageContent({ conversationId: routeConversationId }: AskPageC
   const searchParams = useSearchParams();
   const router = useRouter();
   const [query, setQuery] = useState("");
+  const [images, setImages] = useState<File[]>([]);
 
   const settings = useSettings();
   const config = getPortalConfig(settings);
+  const multimodal = config.ai.multimodal;
   const aiName = config.ai.name;
   const aiAvatar = config.ai.avatar;
   const greeting = config.ai.greeting || "How can I help you today?";
@@ -290,6 +292,11 @@ export function AskPageContent({ conversationId: routeConversationId }: AskPageC
         suggestions={suggestions}
         placeholder="What's on your mind?"
         disclaimer={chatDisclaimer}
+        multimodalEnabled={multimodal.enabled}
+        images={images}
+        onImagesChange={setImages}
+        maxImages={multimodal.maxImages}
+        acceptedMediaTypes={multimodal.acceptedMediaTypes}
       />
     );
   }
@@ -423,6 +430,11 @@ export function AskPageContent({ conversationId: routeConversationId }: AskPageC
                 suggestions={[]}
                 showSuggestions={false}
                 disclaimer={chatDisclaimer}
+                multimodalEnabled={multimodal.enabled}
+                images={images}
+                onImagesChange={setImages}
+                maxImages={multimodal.maxImages}
+                acceptedMediaTypes={multimodal.acceptedMediaTypes}
               />
             </div>
           </div>

--- a/components/ask/ask-page-content.tsx
+++ b/components/ask/ask-page-content.tsx
@@ -157,12 +157,14 @@ export function AskPageContent({ conversationId: routeConversationId }: AskPageC
     async (e?: React.FormEvent) => {
       e?.preventDefault();
       const trimmedQuery = query.trim();
-      if (!trimmedQuery || isStreaming) return;
+      if ((!trimmedQuery && images.length === 0) || isStreaming) return;
 
       setQuery("");
-      await streamQuestion(trimmedQuery);
+      const submittedImages = images;
+      setImages([]);
+      await streamQuestion(trimmedQuery, submittedImages);
     },
-    [query, isStreaming, streamQuestion]
+    [query, images, isStreaming, streamQuestion]
   );
 
   const handleStop = useCallback(() => {

--- a/components/ask/ask-page-content.tsx
+++ b/components/ask/ask-page-content.tsx
@@ -22,6 +22,7 @@ import { AskLoadingState } from "./ask-loading-state";
 import { AskReadOnlyFooter } from "./ask-read-only-footer";
 import { useStreamingScroll } from "@/hooks/use-streaming-scroll";
 import { ScrollToLiveButton } from "@/components/ui/scroll-to-live-button";
+import { AttachmentThumbnails } from "@/components/chat/attachment-thumbnails";
 
 type PageState =
   | { status: "idle" }
@@ -352,7 +353,10 @@ export function AskPageContent({ conversationId: routeConversationId }: AskPageC
                   className="space-y-8"
                   {...(isCurrentlyStreaming ? { "data-streaming-message": true } : {})}
                 >
-                  {/* User's question as title */}
+                  {/* User's question as title, with optional attachment thumbnails */}
+                  {pair.userMessage.attachments && pair.userMessage.attachments.length > 0 && (
+                    <AttachmentThumbnails attachments={pair.userMessage.attachments} />
+                  )}
                   <h2 className="text-2xl font-semibold">{pair.userMessage.content}</h2>
 
                   {/* Loading state */}

--- a/components/ask/ask-page-content.tsx
+++ b/components/ask/ask-page-content.tsx
@@ -154,6 +154,13 @@ export function AskPageContent({ conversationId: routeConversationId }: AskPageC
 
 
 
+  // Drop in-flight image selections if the multimodal capability flips off mid-session
+  useEffect(() => {
+    if (!multimodal.enabled && images.length > 0) {
+      setImages([]);
+    }
+  }, [multimodal.enabled, images.length]);
+
   const handleSubmit = useCallback(
     async (e?: React.FormEvent) => {
       e?.preventDefault();

--- a/components/chat/attachment-lightbox.tsx
+++ b/components/chat/attachment-lightbox.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import { ChatAttachment } from "@/hooks/use-ai-ask-stream";
+
+export function AttachmentLightbox({
+  attachment,
+  onClose,
+}: {
+  attachment: ChatAttachment;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const src = attachment.url ?? attachment.localPreviewUrl;
+  if (!src) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      {/* Plain img is intentional: blob/server URLs are unsuitable for next/image */}
+      <img
+        src={src}
+        alt={attachment.name ?? ""}
+        className="max-h-full max-w-full object-contain"
+        onClick={(e) => e.stopPropagation()}
+      />
+    </div>
+  );
+}

--- a/components/chat/attachment-thumbnails.tsx
+++ b/components/chat/attachment-thumbnails.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import { ChatAttachment } from "@/hooks/use-ai-ask-stream";
+import { AttachmentLightbox } from "./attachment-lightbox";
+
+export function AttachmentThumbnails({
+  attachments,
+}: {
+  attachments: ChatAttachment[];
+}) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+  if (attachments.length === 0) return null;
+  return (
+    <>
+      <div className="flex gap-2 flex-wrap mb-2">
+        {attachments.map((att, i) => {
+          const src = att.url ?? att.localPreviewUrl;
+          if (!src) return null;
+          return (
+            <button
+              key={att.id}
+              type="button"
+              onClick={() => setOpenIndex(i)}
+              className="h-20 w-20 rounded-lg overflow-hidden border border-border hover:border-primary transition-colors"
+              aria-label={`Open attachment ${att.name ?? i + 1}`}
+            >
+              {/* Plain img is intentional: blob/server URLs are unsuitable for next/image */}
+              <img
+                src={src}
+                alt={att.name ?? ""}
+                className="h-full w-full object-cover"
+              />
+            </button>
+          );
+        })}
+      </div>
+      {openIndex !== null && (
+        <AttachmentLightbox
+          attachment={attachments[openIndex]}
+          onClose={() => setOpenIndex(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/components/coach/input.tsx
+++ b/components/coach/input.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useRef, useEffect, useCallback } from "react";
-import { ArrowUp, Square } from "lucide-react";
+import React, { useRef, useEffect, useCallback, useState, useMemo } from "react";
+import { ArrowUp, Square, Paperclip, X } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import { cn } from "@/lib/utils";
 
@@ -18,9 +18,50 @@ interface ChatInputProps {
   showSuggestions?: boolean;
   className?: string;
   disclaimer?: string;
+  // Multimodal (Phase 2)
+  multimodalEnabled?: boolean;
+  images?: File[];
+  onImagesChange?: (images: File[]) => void;
+  maxImages?: number;
+  acceptedMediaTypes?: string[];
 }
 
 const MAX_HEIGHT = 360; // Max height before scrolling
+
+function ThumbnailRow({
+  images,
+  onRemove,
+}: {
+  images: File[];
+  onRemove: (index: number) => void;
+}) {
+  return (
+    <div className="flex gap-2 overflow-x-auto px-3 pt-3">
+      {images.map((file, i) => {
+        const url = URL.createObjectURL(file);
+        // Note: revocation handled by parent on submit/clear, not here.
+        return (
+          <div key={`${file.name}-${i}`} className="relative h-16 w-16 shrink-0">
+            {/* Plain <img> is acceptable here; this is a transient blob URL */}
+            <img
+              src={url}
+              alt={file.name}
+              className="h-16 w-16 rounded-lg object-cover border border-border"
+            />
+            <button
+              type="button"
+              onClick={() => onRemove(i)}
+              className="absolute -top-1 -right-1 rounded-full bg-foreground/80 text-background w-5 h-5 flex items-center justify-center hover:bg-foreground"
+              aria-label={`Remove ${file.name}`}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
 
 export function ChatInput({
   value,
@@ -34,11 +75,23 @@ export function ChatInput({
   suggestions = [],
   showSuggestions = false,
   className,
-  disclaimer
+  disclaimer,
+  multimodalEnabled = false,
+  images: imagesProp,
+  onImagesChange,
+  maxImages: maxImagesProp,
+  acceptedMediaTypes: acceptedMediaTypesProp,
 }: ChatInputProps) {
   const [isFocused, setIsFocused] = React.useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const images = useMemo(() => imagesProp ?? [], [imagesProp]);
+  const maxImages = maxImagesProp ?? 0;
+  const acceptedMediaTypes = useMemo(() => acceptedMediaTypesProp ?? [], [acceptedMediaTypesProp]);
 
   // Auto-resize textarea
   const adjustHeight = useCallback(() => {
@@ -83,9 +136,114 @@ export function ChatInput({
     textareaRef.current?.focus();
   };
 
+  const addImages = useCallback(
+    (incoming: File[]) => {
+      if (!multimodalEnabled || !onImagesChange) return;
+
+      const accepted: File[] = [];
+      let typeRejected = false;
+      for (const f of incoming) {
+        if (acceptedMediaTypes.length && !acceptedMediaTypes.includes(f.type)) {
+          typeRejected = true;
+          continue;
+        }
+        accepted.push(f);
+      }
+
+      let next = [...images, ...accepted];
+      let capHit = false;
+      if (maxImages > 0 && next.length > maxImages) {
+        next = next.slice(0, maxImages);
+        capHit = true;
+      }
+
+      if (typeRejected) {
+        setValidationError(
+          `Unsupported file type. Allowed: ${acceptedMediaTypes.join(", ")}`
+        );
+      } else if (capHit) {
+        setValidationError(`You can attach at most ${maxImages} images.`);
+      } else {
+        setValidationError(null);
+      }
+
+      onImagesChange(next);
+    },
+    [multimodalEnabled, onImagesChange, images, maxImages, acceptedMediaTypes]
+  );
+
+  const removeImage = useCallback(
+    (index: number) => {
+      if (!onImagesChange) return;
+      const next = images.filter((_, i) => i !== index);
+      onImagesChange(next);
+      setValidationError(null);
+    },
+    [images, onImagesChange]
+  );
+
+  const handleFileInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(e.target.files ?? []);
+      if (files.length) addImages(files);
+      e.target.value = ""; // reset so same file can be picked again
+    },
+    [addImages]
+  );
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      if (!multimodalEnabled) return;
+      const items = Array.from(e.clipboardData?.items ?? []);
+      const imageFiles = items
+        .filter((it) => it.kind === "file" && it.type.startsWith("image/"))
+        .map((it) => it.getAsFile())
+        .filter((f): f is File => f !== null);
+      if (imageFiles.length) {
+        e.preventDefault();
+        addImages(imageFiles);
+      }
+    },
+    [multimodalEnabled, addImages]
+  );
+
+  const handleDragOver = useCallback(
+    (e: React.DragEvent<HTMLFormElement>) => {
+      if (!multimodalEnabled) return;
+      if (Array.from(e.dataTransfer.types).includes("Files")) {
+        e.preventDefault();
+        setDragOver(true);
+      }
+    },
+    [multimodalEnabled]
+  );
+
+  const handleDragLeave = useCallback(() => setDragOver(false), []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLFormElement>) => {
+      if (!multimodalEnabled) return;
+      e.preventDefault();
+      setDragOver(false);
+      const files = Array.from(e.dataTransfer.files).filter((f) =>
+        f.type.startsWith("image/")
+      );
+      if (files.length) addImages(files);
+    },
+    [multimodalEnabled, addImages]
+  );
+
   return (
     <div className={cn("w-full", className)}>
-      <form ref={formRef} onSubmit={handleSubmit} className="relative">
+      <form
+        ref={formRef}
+        onSubmit={handleSubmit}
+        className="relative"
+        onDragOver={handleDragOver}
+        onDragEnter={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
         <div
           className={cn(
             "relative flex flex-col rounded-2xl border transition-all duration-200",
@@ -95,11 +253,22 @@ export function ChatInput({
             "bg-background"
           )}
         >
+          {multimodalEnabled && dragOver && (
+            <div className="pointer-events-none absolute inset-0 z-10 rounded-2xl border-2 border-dashed border-primary bg-primary/5 flex items-center justify-center text-primary text-sm">
+              Drop images to attach
+            </div>
+          )}
+
+          {multimodalEnabled && images.length > 0 && (
+            <ThumbnailRow images={images} onRemove={removeImage} />
+          )}
+
           <textarea
             ref={textareaRef}
             value={value}
             onChange={(e) => onChange(e.target.value)}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
             placeholder={placeholder}
@@ -115,8 +284,34 @@ export function ChatInput({
             aria-label="Ask your coach a question"
           />
 
-          {/* Bottom row with submit button */}
-          <div className="flex justify-end px-3 pb-3">
+          {/* Bottom row */}
+          <div className={cn("flex px-3 pb-3", multimodalEnabled ? "justify-between" : "justify-end")}>
+            {multimodalEnabled && (
+              <>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  multiple
+                  accept={acceptedMediaTypes.join(",")}
+                  className="hidden"
+                  onChange={handleFileInputChange}
+                />
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={disabled || isStreaming || (maxImages > 0 && images.length >= maxImages)}
+                  className={cn(
+                    "p-2.5 rounded-xl transition-all duration-200",
+                    "border border-border bg-background hover:bg-accent",
+                    "text-muted-foreground hover:text-foreground",
+                    "disabled:opacity-50 disabled:cursor-not-allowed"
+                  )}
+                  aria-label="Attach images"
+                >
+                  <Paperclip className="h-4 w-4" />
+                </button>
+              </>
+            )}
             {isStreaming && onStop ? (
               <button
                 type="button"
@@ -148,6 +343,10 @@ export function ChatInput({
           </div>
         </div>
       </form>
+
+      {validationError && (
+        <p className="mt-2 text-destructive text-xs px-3">{validationError}</p>
+      )}
 
       {/* Disclaimer */}
       {disclaimer && (

--- a/components/coach/message.tsx
+++ b/components/coach/message.tsx
@@ -7,6 +7,7 @@ import remarkGfm from "remark-gfm";
 import { ChatMessage } from "@/hooks/use-ask-stream";
 import { cn } from "@/lib/utils";
 import { User, AlertCircle } from "lucide-react";
+import { AttachmentThumbnails } from "@/components/chat/attachment-thumbnails";
 
 const LOADING_MESSAGES = [
   "Thinking about that",
@@ -77,6 +78,11 @@ export function MessageBubble({
           <span className="text-xs text-muted-foreground ml-3">
             {aiName}
           </span>
+        )}
+
+        {/* Attachment thumbnails (user messages only) */}
+        {isUser && message.attachments && message.attachments.length > 0 && (
+          <AttachmentThumbnails attachments={message.attachments} />
         )}
 
         {/* Message bubble */}

--- a/components/home/assistant-homepage.tsx
+++ b/components/home/assistant-homepage.tsx
@@ -13,17 +13,22 @@ interface AssistantHomepageProps {
 
 export function AssistantHomepage({ config }: AssistantHomepageProps) {
   const [query, setQuery] = useState("");
+  const [images, setImages] = useState<File[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const router = useRouter();
+  const multimodal = config.ai.multimodal;
 
   const handleSubmit = useCallback(
     async (e?: React.FormEvent) => {
       e?.preventDefault();
       const trimmedQuery = query.trim();
-      
+
       if (!trimmedQuery || isSubmitting) return;
-      
+
       setIsSubmitting(true);
+      // Images are dropped on navigation — submission from homepage is text-only.
+      // Full image submission is available on /ask (Phase 3).
+      setImages([]);
 
       router.push(`/ask?q=${encodeURIComponent(trimmedQuery)}`);
     },
@@ -32,9 +37,9 @@ export function AssistantHomepage({ config }: AssistantHomepageProps) {
 
   // Use AI name as headline, or custom headline if provided
   const aiName = config.ai.name;
-  const headline = config.homepage.assistantConfig?.headline || 
+  const headline = config.homepage.assistantConfig?.headline ||
                    `Ask ${aiName}`;
-  const subheadline = config.homepage.assistantConfig?.subheadline || 
+  const subheadline = config.homepage.assistantConfig?.subheadline ||
                       config.ai.greeting || "I can help with...";
   const suggestions = config.homepage.assistantConfig?.suggestions || [
     "How can I improve my product?",
@@ -50,8 +55,8 @@ export function AssistantHomepage({ config }: AssistantHomepageProps) {
           {/* AI Avatar */}
           {config.ai.avatar && (
             <div className="inline-flex items-center justify-center w-16 h-16 rounded-full overflow-hidden bg-primary/10">
-              <Image 
-                src={config.ai.avatar} 
+              <Image
+                src={config.ai.avatar}
                 alt={aiName}
                 width={64}
                 height={64}
@@ -79,6 +84,11 @@ export function AssistantHomepage({ config }: AssistantHomepageProps) {
             autoFocus={true}
             suggestions={suggestions}
             showSuggestions={true}
+            multimodalEnabled={multimodal.enabled}
+            images={images}
+            onImagesChange={setImages}
+            maxImages={multimodal.maxImages}
+            acceptedMediaTypes={multimodal.acceptedMediaTypes}
           />
         </div>
       </div>

--- a/hooks/use-ai-ask-stream.ts
+++ b/hooks/use-ai-ask-stream.ts
@@ -3,12 +3,23 @@
 import { useState, useCallback, useRef } from "react";
 import { AskCitation } from "@/lib/ask";
 
+export interface ChatAttachment {
+  id: string;
+  url?: string;
+  localPreviewUrl?: string;
+  mimeType: string;
+  width?: number;
+  height?: number;
+  name?: string;
+}
+
 export interface AIAskMessage {
   id: string;
   role: "user" | "assistant";
   content: string;
   type: "text" | "answer" | "error" | "loading";
   sources?: AIAskSource[];
+  attachments?: ChatAttachment[];
 }
 
 export interface AIAskSource {
@@ -87,7 +98,7 @@ export function useAIAskStream(options: UseAIAskStreamOptions = {}) {
   const abortControllerRef = useRef<AbortController | null>(null);
   const streamingMessageIdRef = useRef<string | null>(null);
 
-  const addUserMessage = useCallback((content: string) => {
+  const addUserMessage = useCallback((content: string, attachments?: ChatAttachment[]) => {
     const messageId = `user-${Date.now()}`;
     setMessages((prev) => [
       ...prev,
@@ -96,6 +107,7 @@ export function useAIAskStream(options: UseAIAskStreamOptions = {}) {
         role: "user",
         content,
         type: "text",
+        attachments,
       },
     ]);
     return messageId;
@@ -111,7 +123,16 @@ export function useAIAskStream(options: UseAIAskStreamOptions = {}) {
       const messageId = `assistant-${Date.now()}`;
       streamingMessageIdRef.current = messageId;
 
-      addUserMessage(query);
+      const optimisticAttachments: ChatAttachment[] | undefined =
+        images.length > 0
+          ? images.map((file, i) => ({
+              id: `local-${Date.now()}-${i}`,
+              localPreviewUrl: URL.createObjectURL(file),
+              mimeType: file.type,
+              name: file.name,
+            }))
+          : undefined;
+      const userMessageId = addUserMessage(query, optimisticAttachments);
 
       setMessages((prev) => [
         ...prev,
@@ -283,6 +304,42 @@ export function useAIAskStream(options: UseAIAskStreamOptions = {}) {
                     options.onComplete?.(finalContent, accumulatedSources);
                   }
                 }
+
+                // BOLD-1463: swap optimistic local preview URLs to server-resolved URLs
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const serverAttachments = (event as any).user_attachments as Array<{
+                  id: string;
+                  url?: string;
+                  mime_type?: string;
+                  width?: number;
+                  height?: number;
+                  name?: string;
+                }> | undefined;
+                if (serverAttachments && serverAttachments.length > 0 && optimisticAttachments) {
+                  setMessages((prev) =>
+                    prev.map((msg) => {
+                      if (msg.id !== userMessageId || !msg.attachments) return msg;
+                      const next = msg.attachments.map((att, i) => {
+                        const server = serverAttachments[i];
+                        if (server?.url && att.localPreviewUrl) {
+                          URL.revokeObjectURL(att.localPreviewUrl);
+                          return {
+                            ...att,
+                            url: server.url,
+                            localPreviewUrl: undefined,
+                            mimeType: server.mime_type ?? att.mimeType,
+                            width: server.width,
+                            height: server.height,
+                            name: server.name ?? att.name,
+                          };
+                        }
+                        return att;
+                      });
+                      return { ...msg, attachments: next };
+                    })
+                  );
+                }
+
                 seenTerminalEvent = true;
                 break;
               }

--- a/hooks/use-ai-ask-stream.ts
+++ b/hooks/use-ai-ask-stream.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import { AskCitation } from "@/lib/ask";
 
 export interface ChatAttachment {
@@ -50,11 +50,33 @@ interface BackendSource {
   cited?: boolean;
 }
 
+interface BackendAttachment {
+  id: string;
+  url?: string;
+  mime_type?: string;
+  mimeType?: string;
+  width?: number;
+  height?: number;
+  name?: string;
+}
+
+function normalizeBackendAttachment(raw: BackendAttachment): ChatAttachment {
+  return {
+    id: raw.id,
+    url: raw.url,
+    mimeType: raw.mime_type ?? raw.mimeType ?? "image/*",
+    width: raw.width,
+    height: raw.height,
+    name: raw.name,
+  };
+}
+
 interface ConversationHistoryMessage {
   id: string;
   role: "user" | "assistant";
   content: string;
   sources?: BackendSource[];
+  attachments?: BackendAttachment[];
   insertedAt: string;
 }
 
@@ -444,15 +466,36 @@ export function useAIAskStream(options: UseAIAskStreamOptions = {}) {
     [addUserMessage, conversationId, options]
   );
 
+  const revokeMessageObjectURLs = useCallback((msgs: AIAskMessage[]) => {
+    for (const m of msgs) {
+      m.attachments?.forEach((a) => {
+        if (a.localPreviewUrl) URL.revokeObjectURL(a.localPreviewUrl);
+      });
+    }
+  }, []);
+
   const reset = useCallback(() => {
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     }
-    setMessages([]);
+    setMessages((prev) => {
+      revokeMessageObjectURLs(prev);
+      return [];
+    });
     setConversationId(undefined);
     setIsStreaming(false);
     streamingMessageIdRef.current = null;
-  }, []);
+  }, [revokeMessageObjectURLs]);
+
+  // Revoke any remaining object URLs when the hook unmounts
+  useEffect(() => {
+    return () => {
+      setMessages((prev) => {
+        revokeMessageObjectURLs(prev);
+        return prev;
+      });
+    };
+  }, [revokeMessageObjectURLs]);
 
   const stop = useCallback(() => {
     if (abortControllerRef.current) {
@@ -493,6 +536,7 @@ export function useAIAskStream(options: UseAIAskStreamOptions = {}) {
           content: msg.content,
           type: msg.role === "user" ? "text" : "answer",
           sources: msg.sources?.map(normalizeBackendSource),
+          attachments: msg.attachments?.map(normalizeBackendAttachment),
         });
       }
 

--- a/hooks/use-ai-ask-stream.ts
+++ b/hooks/use-ai-ask-stream.ts
@@ -193,6 +193,10 @@ export function useAIAskStream(options: UseAIAskStreamOptions = {}) {
                 setStatusMessage(event.message ?? null);
                 break;
 
+              case "image_analysis":
+                setStatusMessage(event.message ?? "Analyzing your image…");
+                break;
+
               case "text_delta":
                 setStatusMessage(null);
                 accumulatedResponse += event.delta ?? "";

--- a/hooks/use-ai-ask-stream.ts
+++ b/hooks/use-ai-ask-stream.ts
@@ -102,7 +102,7 @@ export function useAIAskStream(options: UseAIAskStreamOptions = {}) {
   }, []);
 
   const streamQuestion = useCallback(
-    async (query: string) => {
+    async (query: string, images: File[] = []) => {
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
       }
@@ -127,18 +127,30 @@ export function useAIAskStream(options: UseAIAskStreamOptions = {}) {
       setIsStreaming(true);
 
       try {
-        const response = await fetch("/api/ai-ask", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "text/event-stream",
-          },
-          body: JSON.stringify({
-            prompt: query,
-            conversationId,
-          }),
-          signal: abortControllerRef.current.signal,
-        });
+        const useMultipart = images.length > 0;
+        const init: RequestInit = useMultipart
+          ? {
+              method: "POST",
+              headers: { Accept: "text/event-stream" },
+              body: (() => {
+                const fd = new FormData();
+                fd.append("prompt", query);
+                if (conversationId) fd.append("conversationId", conversationId);
+                for (const f of images) fd.append("image", f, f.name);
+                return fd;
+              })(),
+              signal: abortControllerRef.current.signal,
+            }
+          : {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Accept: "text/event-stream",
+              },
+              body: JSON.stringify({ prompt: query, conversationId }),
+              signal: abortControllerRef.current.signal,
+            };
+        const response = await fetch("/api/ai-ask", init);
 
         if (!response.ok) {
           throw new Error(`Request failed with status ${response.status}`);

--- a/hooks/use-ask-stream.ts
+++ b/hooks/use-ask-stream.ts
@@ -6,6 +6,7 @@ import {
   SynthesizedResponse,
   AskCitation
 } from "@/lib/ask";
+import type { ChatAttachment } from "@/hooks/use-ai-ask-stream";
 import { createPlaceholderCitations } from "@/lib/citation-helpers";
 
 export interface ChatMessage {
@@ -17,7 +18,10 @@ export interface ChatMessage {
     clarificationResponse?: ClarificationResponse;
     synthesizedResponse?: SynthesizedResponse;
   };
+  attachments?: ChatAttachment[];
 }
+
+export type { ChatAttachment };
 
 interface MessageStartMessage {
   type: "message_start";
@@ -138,13 +142,14 @@ export function useAskStream(options: UseAskStreamOptions = {}) {
   const abortControllerRef = useRef<AbortController | null>(null);
   const streamingMessageIdRef = useRef<string | null>(null);
 
-  const addUserMessage = useCallback((content: string) => {
+  const addUserMessage = useCallback((content: string, attachments?: ChatAttachment[]) => {
     const messageId = `user-${Date.now()}`;
     setMessages(prev => [...prev, {
       id: messageId,
       role: "user",
       content,
-      type: "text"
+      type: "text",
+      attachments,
     }]);
     return messageId;
   }, []);
@@ -204,7 +209,17 @@ export function useAskStream(options: UseAskStreamOptions = {}) {
 
     abortControllerRef.current = new AbortController();
 
-    addUserMessage(query);
+    const optimisticAttachments: ChatAttachment[] | undefined =
+      images.length > 0
+        ? images.map((file, i) => ({
+            id: `local-${Date.now()}-${i}`,
+            localPreviewUrl: URL.createObjectURL(file),
+            mimeType: file.type,
+            name: file.name,
+          }))
+        : undefined;
+    const userMessageId = addUserMessage(query, optimisticAttachments);
+
     streamingMessageIdRef.current = null;
     addAssistantMessage("", "loading");
     setIsStreaming(true);
@@ -424,6 +439,42 @@ export function useAskStream(options: UseAskStreamOptions = {}) {
 
                   options.onComplete?.(finalResponse);
                 }
+
+                // BOLD-1463: swap optimistic local preview URLs to server-resolved URLs
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const serverAttachments = (message as any).user_attachments as Array<{
+                  id: string;
+                  url?: string;
+                  mime_type?: string;
+                  width?: number;
+                  height?: number;
+                  name?: string;
+                }> | undefined;
+                if (serverAttachments && serverAttachments.length > 0 && optimisticAttachments) {
+                  setMessages((prev) =>
+                    prev.map((msg) => {
+                      if (msg.id !== userMessageId || !msg.attachments) return msg;
+                      const next = msg.attachments.map((att, i) => {
+                        const server = serverAttachments[i];
+                        if (server?.url && att.localPreviewUrl) {
+                          URL.revokeObjectURL(att.localPreviewUrl);
+                          return {
+                            ...att,
+                            url: server.url,
+                            localPreviewUrl: undefined,
+                            mimeType: server.mime_type ?? att.mimeType,
+                            width: server.width,
+                            height: server.height,
+                            name: server.name ?? att.name,
+                          };
+                        }
+                        return att;
+                      });
+                      return { ...msg, attachments: next };
+                    })
+                  );
+                }
+
                 break;
               }
 

--- a/hooks/use-ask-stream.ts
+++ b/hooks/use-ask-stream.ts
@@ -70,6 +70,11 @@ interface ProgressMessage {
   message?: string;
 }
 
+interface ImageAnalysisMessage {
+  type: "image_analysis";
+  message?: string;
+}
+
 interface ErrorMessage {
   type: "error";
   code?: string;
@@ -83,6 +88,7 @@ type StreamMessage =
   | SourcesMessage
   | MessageCompleteMessage
   | ProgressMessage
+  | ImageAnalysisMessage
   | ErrorMessage;
 
 interface UseAskStreamOptions {
@@ -302,6 +308,10 @@ export function useAskStream(options: UseAskStreamOptions = {}) {
 
               case "progress":
                 setStatusMessage(message.message ?? null);
+                break;
+
+              case "image_analysis":
+                setStatusMessage(message.message ?? "Analyzing your image…");
                 break;
 
               case "text_delta":

--- a/hooks/use-ask-stream.ts
+++ b/hooks/use-ask-stream.ts
@@ -189,32 +189,49 @@ export function useAskStream(options: UseAskStreamOptions = {}) {
 
   const streamQuestion = useCallback(async (
     query: string,
-    useConversationId: boolean = true
+    useConversationId: boolean = true,
+    images: File[] = []
   ) => {
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     }
 
     abortControllerRef.current = new AbortController();
-    
+
     addUserMessage(query);
     streamingMessageIdRef.current = null;
     addAssistantMessage("", "loading");
     setIsStreaming(true);
 
     try {
-      const response = await fetch("/api/coach", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "text/event-stream",
-        },
-        body: JSON.stringify({
-          message: query,
-          conversationId: useConversationId ? conversationIdRef.current || undefined : undefined,
-        }),
-        signal: abortControllerRef.current.signal,
-      });
+      const coachConversationId = useConversationId ? conversationIdRef.current || undefined : undefined;
+      const useMultipart = images.length > 0;
+      const init: RequestInit = useMultipart
+        ? {
+            method: "POST",
+            headers: { Accept: "text/event-stream" },
+            body: (() => {
+              const fd = new FormData();
+              fd.append("message", query);
+              if (coachConversationId) fd.append("conversationId", coachConversationId);
+              for (const f of images) fd.append("image", f, f.name);
+              return fd;
+            })(),
+            signal: abortControllerRef.current.signal,
+          }
+        : {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Accept: "text/event-stream",
+            },
+            body: JSON.stringify({
+              message: query,
+              conversationId: coachConversationId,
+            }),
+            signal: abortControllerRef.current.signal,
+          };
+      const response = await fetch("/api/coach", init);
 
       if (!response.ok) {
         const errorText = await response.text().catch(() => "");

--- a/lib/portal-config.ts
+++ b/lib/portal-config.ts
@@ -19,6 +19,11 @@ export interface PortalConfig {
     showInHeader: boolean;
     conversationStarters: string[];
     chatDisclaimer?: string;
+    multimodal: {
+      enabled: boolean;
+      maxImages: number;
+      acceptedMediaTypes: string[];
+    };
   };
   homepage: {
     layout: 'none' | 'library' | 'assistant';
@@ -101,7 +106,12 @@ export function getPortalConfig(rawSettings: Settings | null): PortalConfig {
         greeting: 'Hello! How can I help you today?',
         showInHeader: false,
         conversationStarters: [],
-        chatDisclaimer: undefined
+        chatDisclaimer: undefined,
+        multimodal: {
+          enabled: false,
+          maxImages: 0,
+          acceptedMediaTypes: [],
+        }
       },
       homepage: {
         layout: 'library',
@@ -171,6 +181,17 @@ export function getPortalConfig(rawSettings: Settings | null): PortalConfig {
   // Chat disclaimer (bold-js 1.15.1+)
   const chatDisclaimer = settings.chatDisclaimer;
 
+  // Multimodal capability (snake_case from API, see BOLD-1495)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const multimodalRaw = (settings.account as any)?.multimodal;
+  const multimodal = {
+    enabled: multimodalRaw?.enabled === true,
+    maxImages: typeof multimodalRaw?.max_images === "number" ? multimodalRaw.max_images : 0,
+    acceptedMediaTypes: Array.isArray(multimodalRaw?.accepted_media_types)
+      ? multimodalRaw.accepted_media_types as string[]
+      : [],
+  };
+
   // Determine homepage layout
   const homepageLayout = (layoutOverride ?? settings.portal?.layout?.type ?? 'library') as 'none' | 'library' | 'assistant';
 
@@ -200,7 +221,8 @@ export function getPortalConfig(rawSettings: Settings | null): PortalConfig {
       greeting: aiGreeting,
       showInHeader: showAiInHeader,
       conversationStarters: conversationStarters,
-      chatDisclaimer
+      chatDisclaimer,
+      multimodal
     },
     homepage: {
       layout: homepageLayout,

--- a/lib/portal-config.ts
+++ b/lib/portal-config.ts
@@ -181,15 +181,25 @@ export function getPortalConfig(rawSettings: Settings | null): PortalConfig {
   // Chat disclaimer (bold-js 1.15.1+)
   const chatDisclaimer = settings.chatDisclaimer;
 
-  // Multimodal capability (snake_case from API, see BOLD-1495)
+  // Multimodal capability (BOLD-1495). The SDK normalizes settings keys to
+  // camelCase, but the underlying API contract uses snake_case — accept either.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const multimodalRaw = (settings.account as any)?.multimodal;
+  const multimodalMaxImages =
+    typeof multimodalRaw?.maxImages === "number"
+      ? multimodalRaw.maxImages
+      : typeof multimodalRaw?.max_images === "number"
+        ? multimodalRaw.max_images
+        : 0;
+  const multimodalAcceptedMediaTypes = Array.isArray(multimodalRaw?.acceptedMediaTypes)
+    ? (multimodalRaw.acceptedMediaTypes as string[])
+    : Array.isArray(multimodalRaw?.accepted_media_types)
+      ? (multimodalRaw.accepted_media_types as string[])
+      : [];
   const multimodal = {
     enabled: multimodalRaw?.enabled === true,
-    maxImages: typeof multimodalRaw?.max_images === "number" ? multimodalRaw.max_images : 0,
-    acceptedMediaTypes: Array.isArray(multimodalRaw?.accepted_media_types)
-      ? multimodalRaw.accepted_media_types as string[]
-      : [],
+    maxImages: multimodalMaxImages,
+    acceptedMediaTypes: multimodalAcceptedMediaTypes,
   };
 
   // Determine homepage layout

--- a/middleware.ts
+++ b/middleware.ts
@@ -130,7 +130,6 @@ function shouldSkipPortalAuth(pathname: string): boolean {
   return skipPaths.some((path) => pathname.startsWith(path));
 }
 
-// @ts-ignore next-auth 5 beta types may not match Next.js 16 middleware signature
 export default auth(async (req: NextRequest) => {
   const pathname = req.nextUrl.pathname;
 


### PR DESCRIPTION
## Summary

Implements [BOLD-1496](https://linear.app/boldvideo/issue/BOLD-1496/portal-nextjs-starter-kit-image-upload-ui-in-ai-chat) — image upload UI for the AI chat surfaces (`/ask`, homepage assistant, coach) gated behind the new `multimodal` capability flag.

- Paperclip / drag-drop / clipboard-paste affordances on the shared `ChatInput`, with removable thumbnail previews and inline validation against `maxImages` / `acceptedMediaTypes`. All gated on `config.ai.multimodal.enabled` so consumers without the capability render exactly as today.
- End-to-end submission via `multipart/form-data` from both stream hooks; routes branch on `Content-Type` and forward image bytes to the SDK. Text-only submissions keep the existing JSON path.
- Vision-step status surfacing through the existing `progress` pipeline plus a defensive `image_analysis` discriminant case in routes and hooks.
- Attachments render inline above user-message bubbles via a new shared `AttachmentThumbnails` + `AttachmentLightbox`. Optimistic local previews swap to server URLs on `message_complete`. Object URLs revoked on swap, on `reset()`, and on hook unmount.
- Server-stored attachments rehydrate on `/ask/{conversationId}` reload via a `normalizeBackendAttachment` helper alongside `normalizeBackendSource`. Snake_case + camelCase tolerant.

Phasing followed [`05-plan-image-upload-chat.md`](.humanlayer/tasks/bold-1496-portal-nextjs-starter-kit-image-upload-ui-in-ai-chat/05-plan-image-upload-chat.md): capability plumbing → UI affordances → wire submission → vision status → render attachments → rehydration + flip-off polish.

## Out of scope

- SDK changes — tracked in [BOLD-1449](https://linear.app/boldvideo/issue/BOLD-1449) (separate repo). The portal currently runs against bold-js 1.20.0, which predates the BOLD-1449 PR — `images` and `image_analysis` are forwarded with casts and behave as no-ops at runtime until a release containing PR #51 is published. Bump tracked in [BOLD-1497](https://linear.app/boldvideo/issue/BOLD-1497/portal-bump-boldvideobold-js-to-release-with-bold-1449-image-upload).
- Per-video chat (`/api/ask`), URL-to-screenshot capture (BOLD-1448), client-side image editing.

## Notes

- The SDK normalizes `account.multimodal` keys to **camelCase**, contrary to what the Linear ticket described. The portal-config parser accepts both casings so it works against either contract.
- A dead `@ts-ignore` in `middleware.ts` was removed in passing — the suppression had no remaining target after recent next-auth/Next.js type alignment, and was tripping lint.

## Test plan

- [x] Tenant with `multimodal.enabled = true`: paperclip appears on `/ask` (empty + active) and homepage assistant; file picker scoped to `acceptedMediaTypes`; drag-drop overlay shows on dragover; Cmd/Ctrl+V screenshot adds a thumbnail; over-`maxImages` and disallowed types render inline validation; remove (X) updates the row
- [x] Tenant with `multimodal.enabled = false`: `ChatInput` byte-identical to today (no paperclip, no drop, no paste capture)
- [x] Submit with image(s) on `/ask`: network panel shows `multipart/form-data` POST, thumbnails clear after submit, user bubble shows thumbnails immediately (optimistic)
- [x] Submit text-only: existing JSON path unchanged
- [x] Click thumbnail in user bubble: lightbox opens; Esc and click-outside close; click-on-image does not close
- [x] Reload `/ask/{conversationId}`: server thumbnails rehydrate
- [x] Mid-session capability flip-off: paperclip disappears, in-flight selections clear, in-flight stream continues, past attachments still render

Closes BOLD-1496