### PR TITLE
fix(ask): seek citations to start without clipping playback

### DIFF
--- a/components/ask/ask-video-panel.tsx
+++ b/components/ask/ask-video-panel.tsx
@@ -35,7 +35,6 @@ export function AskVideoPanel({ citation, isOpen, onClose }: AskVideoPanelProps)
   };
 
   const startSeconds = citation.startMs / 1000;
-  const endSeconds = citation.endMs / 1000;
 
   const video: MuxPlayerVideoLike = {
     id: citation.videoId,
@@ -79,13 +78,6 @@ export function AskVideoPanel({ citation, isOpen, onClose }: AskVideoPanelProps)
             startTime={startSeconds}
             autoPlay={true}
             className="w-full h-full"
-            onTimeUpdate={(e: Event) => {
-              const target = e.target as HTMLVideoElement | null;
-              if (!target) return;
-              if (endSeconds > startSeconds && target.currentTime >= endSeconds) {
-                target.pause();
-              }
-            }}
           />
         </div>
 

--- a/components/citation-video-player.tsx
+++ b/components/citation-video-player.tsx
@@ -23,7 +23,6 @@ interface CitationVideoPlayerProps {
   playbackId: string; // Now required from the API
   videoTitle?: string;
   startTime: number; // in seconds
-  endTime?: number;
   label: string;
   speaker?: string;
   isExpanded: boolean;
@@ -35,7 +34,6 @@ export function CitationVideoPlayer({
   playbackId,
   videoTitle,
   startTime,
-  endTime,
   label,
   isExpanded,
   onToggle,
@@ -83,7 +81,7 @@ export function CitationVideoPlayer({
             <span className="font-medium">[{label}]</span>
             {videoTitle && <span className="text-muted-foreground">• {videoTitle}</span>}
             <span className="text-muted-foreground">
-              • {formatTime(startTime)}{endTime ? ` - ${formatTime(endTime)}` : ""}
+              • {formatTime(startTime)}
             </span>
           </div>
         </div>
@@ -95,7 +93,7 @@ export function CitationVideoPlayer({
             </>
           ) : (
             <>
-              <span className="text-xs text-muted-foreground">Watch clip</span>
+              <span className="text-xs text-muted-foreground">Watch</span>
               <ChevronDown className="h-4 w-4" />
             </>
           )}
@@ -117,16 +115,6 @@ export function CitationVideoPlayer({
               autoPlay={false} // We control this manually
               muted={false}
               style={{ width: "100%", height: "100%" }}
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- MuxPlayer event types not exported
-              onTimeUpdate={(e: any) => {
-                // Auto-pause at end time if specified
-                if (endTime && e.target) {
-                  const currentTime = e.target.currentTime;
-                  if (currentTime >= endTime) {
-                    e.target.pause();
-                  }
-                }
-              }}
             />
             
             {/* Video Info Overlay */}
@@ -135,7 +123,7 @@ export function CitationVideoPlayer({
                 <p className="text-white text-sm font-medium mb-1">{videoTitle}</p>
               )}
               <p className="text-white/70 text-xs">
-                Segment: {formatTime(startTime)} - {endTime ? formatTime(endTime) : "end"}
+                Starts at {formatTime(startTime)}
               </p>
             </div>
           </div>

--- a/components/coach/citation.tsx
+++ b/components/coach/citation.tsx
@@ -36,7 +36,6 @@ export function CitationModal({ citation, isOpen, onClose }: CitationModalProps)
   };
 
   const startSeconds = citation.startMs / 1000;
-  const endSeconds = citation.endMs / 1000;
 
   // Transform citation to minimal video object for player (colocated mapper)
   const video: MuxPlayerVideoLike = {
@@ -66,7 +65,7 @@ export function CitationModal({ citation, isOpen, onClose }: CitationModalProps)
               {citation.videoTitle}
             </h3>
             <p className="text-sm text-muted-foreground">
-              {citation.speaker} • {formatTime(citation.startMs)} - {formatTime(citation.endMs)}
+              {citation.speaker} • {formatTime(citation.startMs)}
             </p>
           </div>
           <button
@@ -85,14 +84,6 @@ export function CitationModal({ citation, isOpen, onClose }: CitationModalProps)
             startTime={startSeconds}
             autoPlay={true}
             className="w-full h-full"
-            onTimeUpdate={(e: Event) => {
-              const target = e.target as HTMLVideoElement | null;
-              if (!target) return;
-              // Auto-pause at end time if defined and greater than start time
-              if (endSeconds > startSeconds && target.currentTime >= endSeconds) {
-                target.pause();
-              }
-            }}
           />
         </div>
 

--- a/lib/portal-auth-edge.ts
+++ b/lib/portal-auth-edge.ts
@@ -1,5 +1,13 @@
 import { jwtVerify, type JWTPayload } from "jose";
-import type { NextRequest } from "next/server";
+
+/**
+ * Minimal request shape this module needs: just cookie access.
+ * Typed structurally so it accepts both `NextRequest` and next-auth's
+ * `NextAuthRequest` without coupling to a specific `next` package copy.
+ */
+type RequestWithCookies = {
+  cookies: { get(name: string): { value: string } | undefined };
+};
 
 const PORTAL_SESSION_COOKIE = "portal_session";
 
@@ -35,7 +43,9 @@ export async function verifyPortalSessionEdge(
   }
 }
 
-export function getPortalSessionFromRequest(req: NextRequest): string | null {
+export function getPortalSessionFromRequest(
+  req: RequestWithCookies
+): string | null {
   return req.cookies.get(PORTAL_SESSION_COOKIE)?.value ?? null;
 }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,4 @@
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { isAuthEnabled } from "@/config/auth";
 import { get } from "@vercel/edge-config";
@@ -130,7 +130,7 @@ function shouldSkipPortalAuth(pathname: string): boolean {
   return skipPaths.some((path) => pathname.startsWith(path));
 }
 
-export default auth(async (req: NextRequest) => {
+export default auth(async (req) => {
   const pathname = req.nextUrl.pathname;
 
   if (isHostedMode()) {


### PR DESCRIPTION
## Problem

On the RAG `/ask` page, clicking a citation/timestamp pill opened the video in the side drawer but playback stopped after roughly the snippet duration. After it stopped, seeking elsewhere and pressing play ran for ~0.5s and stopped again.

Root cause: each citation video player attached an inline `onTimeUpdate` handler that called `pause()` whenever `currentTime >= endSeconds` (the citation's `endMs`). The handler was persistent for the life of the component — no fire-once guard, not removed on manual seek — so it re-enforced the snippet boundary forever (the first `timeupdate` after a seek past the end paused instantly).

## Change

Citation playback now seeks to the start point only and plays freely to the video's natural end. No clip. Applied everywhere the pattern existed:

- `components/ask/ask-video-panel.tsx` — `AskVideoPanel`, the `/ask` drawer (the reported bug)
- `components/coach/citation.tsx` — `CitationModal`, the video-detail AI coach drawer; header now shows start time only
- `components/citation-video-player.tsx` — unused inline accordion (dead code); neutralized for consistency, labels de-clipped

No changes to the shared `player-mux.tsx`; its internal analytics timeupdate tracking is unaffected. No Mux-native clipping introduced.

## Out-of-scope fix (pre-existing build blocker)

Verification surfaced a pre-existing `tsc`/`next build` failure in `middleware.ts`, unrelated to this work (confirmed on clean HEAD). Cause: two physical `next` installs — next-auth resolves the pnpm `next@16.1.1` copy while `lib/portal-auth-edge.ts` imported `NextRequest` from the top-level copy; the `NextURL` types are nominally incompatible. Fixed without dependency changes:

- `middleware.ts`: dropped the explicit `: NextRequest` annotation on the `auth()` callback (infers next-auth's `NextAuthRequest`); removed the unused import
- `lib/portal-auth-edge.ts`: narrowed `getPortalSessionFromRequest` to the minimal `{ cookies: { get } }` shape it actually uses, decoupling it from any `next` copy

## Verification

- `bun lint` — clean
- `npx tsc --noEmit` — 0 errors project-wide (was 1 pre-existing)
- `bun run build` — passes end-to-end (was failing on the unrelated middleware error)

### Manual testing needed (reviewer)

- [ ] `/ask` → click a citation pill → drawer video plays past the old snippet end and continues; scrub/seek + play works normally (no ~0.5s stop)
- [ ] Video detail page → AI coach answer citation → `CitationModal` plays freely; header reads `Speaker • 0:30` (start only, no range)

🤖 Generated with [Claude Code](https://claude.com/claude-code)