### PR TITLE
Derive tenant favicon from the header logo

### DIFF
--- a/app/(default)/favicon/route.ts
+++ b/app/(default)/favicon/route.ts
@@ -1,0 +1,50 @@
+import { getTenantContext } from "@/lib/get-tenant-context";
+import { fixUploadUrl } from "@/lib/utils";
+
+// Tenant depends on the request hostname in hosted mode
+export const dynamic = "force-dynamic";
+
+/**
+ * Tenant favicon at /favicon: serves the uploaded favicon if set, otherwise
+ * derives one from the header logo. Logos arrive as webp/svg/wide wordmarks,
+ * so everything is normalized to a square PNG (transparent padding) through
+ * sharp — the same approach as the /og card. Falls back to the static
+ * Bold favicon when the tenant has neither.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const requested = parseInt(searchParams.get("size") || "", 10);
+  const size = Math.min(512, Math.max(16, requested || 64));
+
+  const context = await getTenantContext();
+  const settings = context?.settings;
+  const src =
+    fixUploadUrl(settings?.faviconUrl) || fixUploadUrl(settings?.logoUrl);
+
+  if (src) {
+    try {
+      const res = await fetch(src);
+      if (!res.ok) throw new Error(`upstream ${res.status}`);
+      const input = Buffer.from(await res.arrayBuffer());
+      const { default: sharp } = await import("sharp");
+      const png = await sharp(input)
+        .resize(size, size, {
+          fit: "contain",
+          background: { r: 0, g: 0, b: 0, alpha: 0 },
+        })
+        .png()
+        .toBuffer();
+      return new Response(new Uint8Array(png), {
+        headers: {
+          "Content-Type": "image/png",
+          "Cache-Control":
+            "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+        },
+      });
+    } catch {
+      // fall through to the static favicon
+    }
+  }
+
+  return Response.redirect(new URL("/favicon.ico", request.url), 307);
+}

--- a/app/(default)/layout.tsx
+++ b/app/(default)/layout.tsx
@@ -93,9 +93,13 @@ export async function generateMetadata(): Promise<Metadata> {
       locale: "en-US",
       type: "website",
     },
-    icons: {
-      icon: settings.faviconUrl || "/favicon.ico",
-    },
+    // Explicit favicon wins; otherwise /favicon derives one from the header
+    // logo (normalized to square PNG); static Bold icon as last resort.
+    icons: fixUploadUrl(settings.faviconUrl)
+      ? { icon: fixUploadUrl(settings.faviconUrl) }
+      : settings.logoUrl
+        ? { icon: "/favicon", apple: "/favicon?size=180" }
+        : { icon: "/favicon.ico" },
   };
 }
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -124,7 +124,8 @@ function shouldSkipPortalAuth(pathname: string): boolean {
     "/api/portal-auth",
     "/api/auth",
     "/_next",
-    "/favicon.ico",
+    // Covers /favicon.ico and the tenant-derived /favicon route
+    "/favicon",
     // Social crawlers must reach the OG card even on password-protected portals
     "/og",
   ];


### PR DESCRIPTION
## Summary

Tenants without an uploaded favicon (e.g. bt_monarch_health) fell back to the generic Bold favicon even though their header logo is set.

- New `/favicon` route: serves the uploaded favicon when present, otherwise the header logo (`settings.logoUrl`) normalized to a square PNG through sharp — webp/svg uploads and wide wordmarks are handled with transparent contain-fit padding; `?size=` (16–512, default 64) picks the dimension
- Root layout metadata points `icon` at `/favicon` and `apple-touch-icon` at `/favicon?size=180` when no explicit favicon is set; an uploaded favicon keeps winning untouched
- Portal auth skips `/favicon` so password-protected portals still get their icon
- Static Bold `/favicon.ico` remains the last resort (redirect) when a tenant has neither

## Testing

- Hosted-mode dev against monarch-health: webp badge logo renders as clean square PNG at 64 and 180, `<link rel="icon">`/`apple-touch-icon` point at the route
- Hosted-mode dev against goatmire: SVG wordmark rasterizes and pads to square correctly
- `bun run build` and `bun lint` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/boldvideo/codesmith/nextjs-starter/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789395462&installation_model_id=22292&pr_number=41&repository=boldvideo%2Fnextjs-starter&return_to=https%3A%2F%2Fgithub.com%2Fboldvideo%2Fnextjs-starter%2Fpull%2F41&signature=b00f59216ae3cbb76e3fc48239c0a58f240f24a9978e55413bc6d5dd97cd5b63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant-specific favicon support.
  * Favicons now prioritize configured images, then generate one from the tenant logo.
  * Generated icons are converted to square, transparent PNGs and cached for faster loading.
  * Added a fallback to the default favicon if a tenant icon cannot be retrieved or processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->